### PR TITLE
Mmch

### DIFF
--- a/app/assets/javascripts/admin/user_sessions.coffee
+++ b/app/assets/javascripts/admin/user_sessions.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/admin/user_sessions.scss
+++ b/app/assets/stylesheets/admin/user_sessions.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admin::user_sessions controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/admin/user_sessions_controller.rb
+++ b/app/controllers/admin/user_sessions_controller.rb
@@ -1,0 +1,21 @@
+class Admin::UserSessionsController < ApplicationController
+
+
+
+#(仮)
+
+	skip_before_action :require_login, except: [:destroy], raise: false
+
+    def new
+       省略
+    end
+
+    def create
+　　　　省略
+    end
+
+    def destroy
+　　　　省略
+    end
+
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,4 +7,15 @@ class ApplicationController < ActionController::Base
   # def configure_permitted_parameters
   #   devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
   # end
+
+
+  layout "admin"
+
+    protected
+
+    def not_authenticated
+      redirect_to "/admin/login"
+    end
+
+
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -6,6 +6,11 @@ class ProductsController < ApplicationController
   end
 
   def new
+    @products = Product.new
+    @artists = Artist.new
+    @genres = Genre.new
+    @labels = Label.new
+    @arrivails = Arrival.new
   end
 
   def create

--- a/app/helpers/admin/user_sessions_helper.rb
+++ b/app/helpers/admin/user_sessions_helper.rb
@@ -1,0 +1,2 @@
+module Admin::UserSessionsHelper
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,5 +2,4 @@ class Product < ApplicationRecord
 	enum status: {
 		販売中:1,販売停止中:2
 	}
-
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,2 +1,6 @@
 class Product < ApplicationRecord
+	enum status: {
+		販売中:1,販売停止中:2
+	}
+
 end

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -1,2 +1,22 @@
-<h1>Products#new</h1>
-<p>Find me in app/views/products/new.html.erb</p>
+
+
+<%= form_with  model: @product do |f| %>
+
+
+<div class="field">
+  <h2>商品追加(仮)</h2><br>
+
+
+
+
+
+
+  <%= f.string_field :artist_name %>
+  <%= f.string_field :product_name %>
+  
+
+  <%= f.select :status, Product.statuses.keys, {prompt: '選択してください'} %>
+</div>
+
+
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,18 @@ Rails.application.routes.draw do
   get 'admins/top'
 
 
+
+# 管理者用ログイン画面へのルーティング(仮)
+   #get "/admin/login" => "admin/user_sessions#new"
+
+# 管理者ログイン後のURLに/admins/..を追加
+  namespace :admin do
+    resources :user_sessions, only: [:create, :destroy]
+    resources :dashboards
+  end
+
+
+
   resources :arrivals, only: [:index, :show, :new, :create]
 
   resources :stocks, only: [:create, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   resources :admins, only: [:index, :show]
   get 'admins/top'
 
+
   resources :arrivals, only: [:index, :show, :new, :create]
 
   resources :stocks, only: [:create, :update]

--- a/test/controllers/admin/user_sessions_controller_test.rb
+++ b/test/controllers/admin/user_sessions_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Admin::UserSessionsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
・管理者用URL追加
管理者ログインしているとき、URLの前に /admin/.. が記述される機能を追加

・user_sessions_controller.rb　の追加
https://kurose.me/namespace-admin/
上記URLのネームスペースについての記事を参考にして、新しくコントローラ "user_sessions_controller.rb" を作っています・・・が、管理者用ログイン機能に関する記述やファイルはグッチの記述に合わせたいので、変更・削除の可能性はあると思います。

・routes.rb にも、
get "/admin/login" => "admin/user_sessions#new"　を記述していますが、これもグッチの記述に合わせて変更したり削除する可能性があると思います。

-------

・products/new画面にて、
販売ステータスのセレクト機能追加
（ あとで管理者用の商品追加ページにコードを移動する )
